### PR TITLE
Fix ubuntu20.04 catkin_make and rviz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(semantic_bki)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -o3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -o3")
 
 find_package(OpenMP)
 if (OPENMP_FOUND)

--- a/include/semantic_bki/common/markerarray_pub.h
+++ b/include/semantic_bki/common/markerarray_pub.h
@@ -407,7 +407,7 @@ namespace semantic_bki {
                                                                                   msg(new visualization_msgs::MarkerArray),
                                                                                   topic(topic),
                                                                                   resolution(resolution),
-                                                                                  markerarray_frame_id("/map") {
+                                                                                  markerarray_frame_id("map") {
             pub = nh.advertise<visualization_msgs::MarkerArray>(topic, 1, true);
 
             msg->markers.resize(2);

--- a/include/semantic_bki/dataset_devkit/kitti_util.h
+++ b/include/semantic_bki/dataset_devkit/kitti_util.h
@@ -3,7 +3,7 @@
 #include <fstream>
 
 #include <Eigen/Dense>
-#include <opencv/cv.hpp>
+#include <opencv2/opencv.hpp>
 #include <opencv2/core/core.hpp>
 #include <pcl/common/transforms.h>
 

--- a/src/kitti_node.cpp
+++ b/src/kitti_node.cpp
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
       std::string depth_img_name(dir + "/" + depth_img_prefix + "/" + scan_id_s + ".png");
       std::string label_bin_name(dir + "/" + label_bin_prefix + "/" + scan_id_s + ".bin");
 
-    	cv::Mat depth_img = cv::imread(depth_img_name, CV_LOAD_IMAGE_ANYDEPTH);
+    	cv::Mat depth_img = cv::imread(depth_img_name, cv::IMREAD_ANYDEPTH);
     	kitti_data.read_label_prob_bin(label_bin_name);
       kitti_data.process_depth_img(scan_id, depth_img, cloud, origin, reproject);
       


### PR DESCRIPTION
Hello Lu Gan,
I am a student of ROB530 Mobile Robotics (lectured by professor Manni) and walked into your code for the assignment. It seems like the code has only been tested on ubuntu 16 and 18 machines. I used an ubuntu 20 computer and faced some errors during the catkin_make and rviz process. I solved these issues by the following steps. I hope those replacements can be helpful to your repository.

1. In CamkeLists.txt Line 4: **Replace** set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -o3") **to** set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -o3")


2. In include/semantic_bki/dataset_devkit/kitti_util.h Line 6: **change** #include <opencv/cv.hpp> **to** #include <opencv2/opencv.hpp>


3. In src/kitti_node.cpp Line 139: **change** CV_LOAD_IMAGE_ANYDEPTH **to** cv::IMREAD_ANYDEPTH


4. In include/semantic_bki/common/markerarray_pub.h Line 410: **change** /map **to** map