### PR TITLE
Add return statement to fix undefined behavior in `LeafIterator::&operator++()`

### DIFF
--- a/include/semantic_bki/mapping/bkioctomap.h
+++ b/include/semantic_bki/mapping/bkioctomap.h
@@ -263,6 +263,7 @@ namespace semantic_bki {
                         end_leaf = block_it->second->end_leaf();
                     }
                 }
+                return *this;
             }
 
             SemanticOcTreeNode &operator*() const {


### PR DESCRIPTION
Currently one of the ++ operators on the `LeafIterator` class omits a return statement which is undefined behavior. See the compile warning:

```
[semantic_bki:make] ~/catkin_ws/src/BKISemanticMapping/include/semantic_bki/mapping/bkioctomap.h:266:13: warning: non-void function does not return a value [-Wreturn-type]
[semantic_bki:make]             }
[semantic_bki:make]
```

On my compiler (Clang 16) this generates a `ud2` instruction which causes `SIGILL`, preventing any iterations from running:
```
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── code:x86:64 ────
   0x555555641355 <semantic_bki::SemanticBKIOctoMap::LeafIterator::operator++()+261> call   0x5555556045b0 <_ZN12semantic_bki14SemanticOcTree12LeafIteratorD2Ev>
   0x55555564135a <semantic_bki::SemanticBKIOctoMap::LeafIterator::operator++()+266> jmp    0x555555641366 <_ZN12semantic_bki18SemanticBKIOctoMap12LeafIteratorppEv+278>
   0x55555564135f <semantic_bki::SemanticBKIOctoMap::LeafIterator::operator++()+271> jmp    0x555555641364 <_ZN12semantic_bki18SemanticBKIOctoMap12LeafIteratorppEv+276>
 → 0x555555641364 <semantic_bki::SemanticBKIOctoMap::LeafIterator::operator++()+276> ud2    
   0x555555641366 <semantic_bki::SemanticBKIOctoMap::LeafIterator::operator++()+278> mov    rdi, QWORD PTR [rbp-0x30]
   0x55555564136a <semantic_bki::SemanticBKIOctoMap::LeafIterator::operator++()+282> call   0x5555555ef770 <_Unwind_Resume@plt>
   0x55555564136f                  nop    
   0x555555641370 <semantic_bki::MarkerArrayPub::publish()+0> push   rbp
   0x555555641371 <semantic_bki::MarkerArrayPub::publish()+0> mov    rbp, rsp
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── source:/home/quintin/c[...].h+259 ────
    254	                 return result;
    255	             }
    256	 
    257	             LeafIterator &operator++() {
    258	                 ++leaf_it;
 →  259	                 if (leaf_it == end_leaf) {
    260	                     ++block_it;
    261	                     if (block_it != end_block) {
    262	                         leaf_it = block_it->second->begin_leaf();
    263	                         end_leaf = block_it->second->end_leaf();
    264	                     }
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── threads ────
[#0] Id 1, Name: "semantickitti_n", stopped 0x555555641364 in semantic_bki::SemanticBKIOctoMap::LeafIterator::operator++ (), reason: SIGILL
```

Adding a simple return statement of `*this` fixes it for me.